### PR TITLE
Add more scopes

### DIFF
--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -245,6 +245,16 @@
 (class_declaration (base_clause (name) @entity.other.inherited-class.php))
 (class_declaration (class_interface_clause (name) @entity.other.implemented-interface.php))
 
+; the "Foo" and "bar" in `Foo::bar`
+(class_constant_access_expression . (name) @support.class.php)
+(class_constant_access_expression (name) @variable.other.property.php .)
+
+; the "Foo" and "$bar" in Foo::$bar
+(scoped_property_access_expression
+  scope: (name) @support.class.php
+  name: (variable_name) @variable.other.property.static.php
+  (#set! capture.final true))
+
 ; Static method calls.
 (scoped_call_expression
   scope: (name) @support.class.php

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -245,6 +245,17 @@
 (class_declaration (base_clause (name) @entity.other.inherited-class.php))
 (class_declaration (class_interface_clause (name) @entity.other.implemented-interface.php))
 
+; usage or consumption of traits
+(use_declaration (name) @entity.name.type.trait.php)
+; in use lists, "bar" in `Foo::bar` is a method, not a constant
+(use_list
+  (_
+    (class_constant_access_expression (name) @support.other.function.method.php .)
+    (name) @support.other.function.method.php
+  )
+  (#set! capture.final true)
+)
+
 ; the "Foo" and "bar" in `Foo::bar`
 (class_constant_access_expression . (name) @support.class.php)
 (class_constant_access_expression (name) @variable.other.property.php .)

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -285,6 +285,14 @@
 
 (interface_declaration (name) @entity.name.type.interface.php)
 
+; ENUMS
+; =====
+
+(enum_declaration
+  name: (name) @entity.name.type.enum.php
+  (enum_declaration_list
+    (enum_case
+      name: (name) @constant.other.enum.php)))
 
 ; TYPES
 ; =====
@@ -296,7 +304,7 @@
 
 "global" @storage.modifier.global.php
 
-["interface" "trait" "class"] @storage.type._TYPE_.php
+["enum" "interface" "trait" "class"] @storage.type._TYPE_.php
 "function" @storage.type.function.php
 "fn" @storage.type.function.arrow.php
 

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -261,6 +261,11 @@
 
 (trait_declaration (name) @entity.name.type.trait.php)
 
+; INTERFACES
+; ======
+
+(interface_declaration (name) @entity.name.type.interface.php)
+
 
 ; TYPES
 ; =====
@@ -272,7 +277,7 @@
 
 "global" @storage.modifier.global.php
 
-["trait" "class"] @storage.type._TYPE_.php
+["interface" "trait" "class"] @storage.type._TYPE_.php
 "function" @storage.type.function.php
 "fn" @storage.type.function.arrow.php
 
@@ -375,7 +380,6 @@
   "include_once"
   "include"
   "insteadof"
-  "interface"
   "namespace"
   "new"
   "require_once"

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -354,7 +354,6 @@
 
 
 [
-  "abstract"
   "as"
   "break"
   "case"
@@ -393,6 +392,7 @@
 ] @keyword.control._TYPE_.php
 
 [
+  "abstract"
   "final"
   "private"
   "protected"

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -247,13 +247,11 @@
 
 ; Static method calls.
 (scoped_call_expression
+  scope: (name) @support.class.php
   name: (name) @support.other.function.method.static.php)
 
 (member_call_expression
   name: (name) @support.other.function.method.php)
-
-(scoped_call_expression
-  scope: (name) @support.class.php)
 
 
 ; TRAITS

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -303,9 +303,9 @@
       "$" @punctuation.definition.variable.php
     ) @variable.parameter.php))
 
-; The "$bar" in `$foo->$bar`.
+; The "bar" and "$bar" in `$foo->bar` and `$foo->$bar`.
 (member_access_expression
-  name: (variable_name) @variable.other.property.php
+  name: [(name) (variable_name)] @variable.other.property.php
   (#set! capture.final true))
 
 ((variable_name

--- a/packages/language-php/grammars/tree-sitter/queries/highlights.scm
+++ b/packages/language-php/grammars/tree-sitter/queries/highlights.scm
@@ -515,7 +515,15 @@
   "-="
   "*="
   "/="
+  "%="
+  "**="
+  "&="
+  "|="
+  "^="
+  "<<="
+  ">>="
   ".="
+  "??="
 ] @keyword.operator.assignment.compound.php
 
 "->" @keyword.operator.class.php


### PR DESCRIPTION
Hi, I had to open this here because your branch only exists in your repo, not on the main pulsar repo, which I guess makes sense. I did not add tests for these, but I did follow the [*sweet* instructions ](https://gist.github.com/savetheclocktower/c9607b97477d4817911e4f2f8db89679#file-grammar-authoring-crash-course-md) you posted to make these edits and watch the highlights update live. 🪄 

I think the commits speak for themselves, but the gist is:
- fix `interface`
- fix `abstract`
- support `$foo->bar`, `Foo::bar` and `Foo::$bar`
- support trait usage, ie `use Foo` in a class, not as a namespace import
- support emums
- support missing compound operators